### PR TITLE
Create user account independent of app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ To-do: Write guide. Include Nginx proxy conf & systemd service unit.
 - Automatically check IPs via ipinfo API? This would use up a free plan quickly- check each IP only once. 
 - Script to test high request volume, fuzz
 - Filter out private IP spaces on stats pages?
-- Script to create user acct
+- Script to create first user acct

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Initialize database:
 
 `python db_initialize.py`
 
+Create a login:
+
+`python create-user.py <username>`
+
 Run the app:
 
 `export FLASK_APP=project`
@@ -46,11 +50,13 @@ An example systemd service unit file is included, see `/etc/systemd/system/honey
 To-do: Write guide. Include Nginx proxy conf & systemd service unit. 
 
 # Extra scripts for testing
-`test-send-request.py` | Sends a POST request to localhost:5000 for testing. Accepts up to 2 parameters, which are used as the post data. For ex., to send `{'key1', 'value1'}` you would run `./send-request.py key1 value1`. If no parameters input then some default data is used. Can also do something like `./send-request.py $(head -c 32 /dev/urandom)`
+`test-send-request.py` | Sends a POST request to localhost:5000 for testing. Accepts up to 2 parameters, which are used as the post data. For ex., to send `{'key1', 'value1'}` you would run `python test-send-request.py key1 value1`. If no parameters input then some default data is used. Can also do something like `./test-send-request.py $(head -c 32 /dev/urandom)` in a Bash shell.
 
 `test-highvolume.py` | Send a bunch of GET + POST requests to localhost:5000, for testing with higher volume. Creates a handful of threads. Change IP in script if not running on localhost. 
 
-`create-venv.sh` | Creates a venv named `venv` in the current directory.
+`test-post-bad-data.py` | POST some random data, not JSON-formatted.
+
+`create-venv.sh` | Just creates a venv named `venv` in the current directory.
 
 `deploy.sh` | This is NOT for production deployment, it only copies the main app files to another machine for development purposes - I use it to copy over new versions of the Flask blueprints to my "production" server where the app is already deployed. 
 
@@ -66,4 +72,3 @@ To-do: Write guide. Include Nginx proxy conf & systemd service unit.
 - Automatically check IPs via ipinfo API? This would use up a free plan quickly- check each IP only once. 
 - Script to test high request volume, fuzz
 - Filter out private IP spaces on stats pages?
-- Script to create first user acct

--- a/create-user.py
+++ b/create-user.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+""" Create a user account and add it to the database. Usage: python create-user.py <username> """
+
+import argparse
+from werkzeug.security import generate_password_hash, check_password_hash
+from project import create_app, db, models
+
+app = create_app()
+
+# parse command line arguments
+parser = argparse.ArgumentParser(description = 'Create user account.')
+parser.add_argument('username', type = ascii, nargs = '?', help = 'Username for new account.')
+args = parser.parse_args()
+
+# Create a user account
+def create_new_user():
+    """ Prompt for creds, create new user and add to db """
+
+    if args.username:
+        user_username = args.username
+    else:
+        user_username = input('Username for new account:\n')
+
+    with app.app_context():
+        # if this returns a user, then username already exists in database
+        user = models.User.query.filter_by(username=user_username).first()
+
+        if user:
+            print('Error: Username already exists.\n')
+            quit()
+
+        # Prompt for a password to use
+        user_password = input(str('Password for new account:\n'))
+
+        # create a new user with the form data. Hash the password so the plaintext version isn't saved.
+        new_user = models.User(username=user_username, password=generate_password_hash(user_password))
+
+        # add the new user to the database
+        db.session.add(new_user)
+        db.session.commit()
+
+        print('User created successfully.')
+
+if __name__ == '__main__':
+    create_new_user()

--- a/project/auth.py
+++ b/project/auth.py
@@ -90,14 +90,14 @@ def login_post():
     return redirect(url_for('main.stats'))
 
 @auth.route('/signup')
-#@login_required
+@login_required
 def signup():
     return render_template('signup.html')
 
 # Note: After creating an account, add @login_required decorator to signup_post so
 # you must be logged in to create more accts.
 @auth.route('/signup', methods=['POST'])
-#@login_required
+@login_required
 def signup_post():
     """Validate and add user to database"""
     username = request.form.get('username')

--- a/project/main.py
+++ b/project/main.py
@@ -11,7 +11,7 @@ from flask_login import login_required, current_user
 main = Blueprint('main', __name__)
 
 # Initialize bots database
-# Should move this to __init__.py and use sqlAlchemy to do it
+# Should move this to models.py as a sqlAlchemy model, since I switched to blueprints.
 def createDatabase(): # note: change column names to just match http headers, this schema is stupid and confusing.
     """ Create the bots.db database that will contain all the requests data. """
     conn = sqlite3.connect("bots.db")
@@ -33,10 +33,9 @@ def createDatabase(): # note: change column names to just match http headers, th
     conn.commit()
     c.close()
     conn.close()
-    print('Bots database initialized.')
+    #print('Bots database initialized.')
 
-    # Create Logins table for attempts at the FAKE login
-    # Might do away with the fake route and just use this table to log any failed logins, since the fake one doesn't get hits anyway.
+    # Create Logins table
     conn = sqlite3.connect("bots.db")
     c = conn.cursor()
     c.execute("""
@@ -51,7 +50,7 @@ def createDatabase(): # note: change column names to just match http headers, th
     conn.commit()
     c.close()
     conn.close()
-    print('Logins database intialized.')
+    #print('Logins database intialized.')
 
 createDatabase()
 
@@ -66,7 +65,7 @@ def inject_title():
 @main.route('/<path:u_path>', methods = ['POST', 'GET'])
 def index(u_path):
     """ Catch-all route. Get and save all the request data into the database. """
-    #print(request) #for testing
+    print(request) #for testing/ journalctl
 
     ## note: I *really* need to change these variable names to match the database/headers better
 

--- a/project/shared_functions.py
+++ b/project/shared_functions.py
@@ -1,0 +1,39 @@
+""" Shared helper functions. """
+
+import datetime
+import sqlite3
+from flask import request
+
+def get_ip():
+    """ Get client's IP from behind Nginx. """
+    if 'X-Real-Ip' in request.headers:
+        clientIP = request.headers.get('X-Real-Ip') #get real ip from behind Nginx
+    else:
+        clientIP = request.remote_addr
+    return clientIP
+
+def insert_login_record(username, password):
+    """ sql insert helper function, for logging auth attempts. """
+
+    if 'X-Real-Ip' in request.headers:
+        clientIP = request.headers.get('X-Real-Ip') #get real ip from behind Nginx
+    else:
+        clientIP = request.remote_addr
+    loginTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    #make the sqlite insert
+    try:
+        conn = sqlite3.connect('bots.db')
+        c = conn.cursor()
+        sqlQuery = """
+            INSERT INTO logins
+            (id,remoteaddr,username,password,time)
+            VALUES (NULL, ?, ?, ?, ?);
+            """
+        dataTuple = (clientIP, username, password, loginTime)
+        c.execute(sqlQuery, dataTuple)
+        conn.commit()
+    except sqlite3.Error as e:
+        print(f'Error inserting login record: {e}')
+    finally:
+        conn.close()

--- a/project/templates/loginstats.html
+++ b/project/templates/loginstats.html
@@ -13,8 +13,8 @@
 	<div class="everything"><center>
         <h1>Stats -> Logins</h1>
         <div class="content">
-            <p>Total failed logins in database: {{totalLogins}}</p>
-            <h2>Most Recent failed logins </h2>
+            <p>Total auth attempts in database: {{totalLogins}}</p>
+            <h2>Most recent login attempts: </h2>
 
             <div id="dataToggles">
                 Toggle data columns:


### PR DESCRIPTION
Add create-user.py to create login accounts outside of app; replaces @auth.route('/signup'). Imports the Flask app context, database models, and adds the user account to the database.
Also introduces a helper module shared_functions.py with some logging functions for database inserts.

- Script: create-user.py
- Usage: python create_user.py <username>
- Usage example: python create-user.py john_doe