### PR TITLE
More stats view functions, redact cookies, ISO8601 timestamps, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -327,3 +327,4 @@ download-db.sh
 test-scripts/
 launch.sh
 untracked/
+config.py

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -4,7 +4,6 @@ import secrets
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
-from werkzeug.urls import url_decode
 
 # init SQLAlchemy so we can use it later in our models
 db = SQLAlchemy()

--- a/project/config.py
+++ b/project/config.py
@@ -1,6 +1,6 @@
 """Make any extra flask app.config adjustments here to override defaults """
 
-import secrets
+#import secrets
 
 SECRET_KEY = secrets.token_hex() #Use a static value in production or else cookies won't stay valid
 PERMANENT_SESSION_LIFETIME = 86400

--- a/project/config.py
+++ b/project/config.py
@@ -1,6 +1,6 @@
 """Make any extra flask app.config adjustments here to override defaults """
 
-#import secrets
+import secrets
 
 SECRET_KEY = secrets.token_hex() #Use a static value in production or else cookies won't stay valid
 PERMANENT_SESSION_LIFETIME = 86400

--- a/project/main.py
+++ b/project/main.py
@@ -81,8 +81,11 @@ def index(u_path):
     clientUserAgent = request.headers.get('User-Agent')
     reqMethod = request.method
     clientQuery = request.environ.get("QUERY_STRING")
-    clientTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    #clientTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    clientTime = datetime.datetime.now().isoformat() #ISO8601
     clientHeaders = dict(request.headers) # go ahead and save the full headers
+    if 'Cookie' in clientHeaders:
+        clientHeaders['Cookie'] = '[REDACTED]' # Don't expose session cookies!
     reqUrl = request.url
 
     # Get the POSTed data

--- a/project/main.py
+++ b/project/main.py
@@ -170,7 +170,7 @@ def stats():
 @main.route('/loginstats')
 @login_required
 def loginStats():
-    """ Query db for login attempts to the FAKE login route. """
+    """ Query db for login attempts. """
     conn = sqlite3.connect('bots.db')
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
@@ -237,6 +237,80 @@ def methodStats(method):
         totalHits = len(methodStats),
         statName = method
         )
+
+@main.route('/stats/useragent', methods = ['GET'])
+@login_required
+def uaStats():
+    ua = request.args.get('ua', '')
+    """ Get stats matching the user agent string. """
+    conn = sqlite3.connect('bots.db')
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    # Query for matching user agent
+    sqlQuery = """
+        SELECT * FROM bots WHERE useragent = ? ORDER BY id DESC;
+        """
+    dataTuple = (ua,)
+    c.execute(sqlQuery, dataTuple)
+    uaStats = c.fetchall()
+    c.close()
+    conn.close()
+
+    return render_template('stats.html',
+        stats = uaStats,
+        totalHits = len(uaStats),
+        statName = "User-Agent: " + ua
+        )
+
+@main.route('/stats/url', methods = ['GET'])
+@login_required
+def urlStats():
+    url = request.args.get('url', '')
+    """ Get stats matching the URL. """
+    conn = sqlite3.connect('bots.db')
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    # Query for matching user agent
+    sqlQuery = """
+        SELECT * FROM bots WHERE url = ? ORDER BY id DESC;
+        """
+    dataTuple = (url,)
+    c.execute(sqlQuery, dataTuple)
+    urlStats = c.fetchall()
+    c.close()
+    conn.close()
+
+    return render_template('stats.html',
+        stats = urlStats,
+        totalHits = len(urlStats),
+        statName = "URL: " + url
+        )
+
+@main.route('/stats/query', methods = ['GET'])
+@login_required
+def queriesStats():
+    query_params = request.args.get('query', '')
+    """ Get stats matching the Query String. """
+    conn = sqlite3.connect('bots.db')
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    # Query for matching user agent
+    sqlQuery = """
+        SELECT * FROM bots WHERE querystring = ? ORDER BY id DESC;
+        """
+    dataTuple = (query_params,)
+    c.execute(sqlQuery, dataTuple)
+    queriesStats = c.fetchall()
+    c.close()
+    conn.close()
+
+    return render_template('stats.html',
+        stats = queriesStats,
+        totalHits = len(queriesStats),
+        statName = "Query String: " + query_params
+        )
+
+# Misc routes
 
 @main.route('/profile')
 @login_required

--- a/project/static/css/style.css
+++ b/project/static/css/style.css
@@ -1,5 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Abel&family=Gemunu+Libre&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Gemunu+Libre:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300&family=Oxygen+Mono&display=swap');
 
 :root {
 	--main-bg-color: #111828;
@@ -17,6 +19,7 @@
 	--nav-submenu-bg: #6b818c;
 	--font1: "Gemunu Libre";
 	--font2: "Abel";
+	--mono-font: "Oxygen Mono";
 	--orange1: #FF7F02;
 	--white1: #FFFFFF;
 	--darkblue: #111828;
@@ -367,7 +370,7 @@ td{
 }
 
 /* Limit max width of Headers and Post Data columns, otherwise they get huge */
-td.dataHeaders, td.dataPostData {
+td.dataHeaders, td.dataPostData, td.dataURL {
 	max-width: 600px;
 }
 
@@ -375,8 +378,13 @@ td.dataMethod{
 	/* width: 5%; */
 }
 
-td.httpHeaders {
+/* For a couple columns that I want to shrink a little */
+td.smaller {
 	font-size: 0.8em;
+}
+
+td.smallerer {
+	font-size: 0.7em;
 }
 
 table thead tr th {
@@ -384,6 +392,7 @@ table thead tr th {
 	/* color: var(--main-accent-color); */
 	padding-bottom: 1em;}
 
+/* remote IP on the stats page */
 td.ipToLink {
 	/* color: var(--main-heading-color); */
 }
@@ -394,6 +403,24 @@ td.ipToLink a {
 
 td.ipToLink a:hover {
 	text-decoration: underline;
+}
+
+/* For data columns that I'll turn into links, so it's not distracting */
+.dataToLink a {
+	color: var(--main-text-color);
+	text-decoration: none;
+}
+
+td.dataToLink a:hover {
+	background-color: #1b2433;
+}
+
+.mono {
+	font-family: var(--mono-font);
+}
+
+.dim {
+	filter:opacity(50%);
 }
 
 /* for jQuery hiding columns */

--- a/project/static/css/style.css
+++ b/project/static/css/style.css
@@ -366,7 +366,7 @@ td{
 	/* width: 9%; */
 }
 
-/* Limit max width of Headers and Post Data columns*/
+/* Limit max width of Headers and Post Data columns, otherwise they get huge */
 td.dataHeaders, td.dataPostData {
 	max-width: 600px;
 }
@@ -382,7 +382,7 @@ td.httpHeaders {
 table thead tr th {
 	display: flexbox;
 	/* color: var(--main-accent-color); */
-}
+	padding-bottom: 1em;}
 
 td.ipToLink {
 	/* color: var(--main-heading-color); */

--- a/project/static/css/style.css
+++ b/project/static/css/style.css
@@ -404,7 +404,7 @@ td.ipToLink a:hover {
 /* for default hidden stats columns */
 .hidden {
 	display: none;
-	content-visibility: hidden;
+	/* content-visibility: hidden; */ /* This is making it not display at all, even after toggling the checkbox */
 }
 
 /* END TABLE DATA */

--- a/project/static/css/style.css
+++ b/project/static/css/style.css
@@ -1,7 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Abel&family=Gemunu+Libre&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Gemunu+Libre:wght@300&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300&family=Oxygen+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Oxygen+Mono&display=swap');
 
 :root {
 	--main-bg-color: #111828;

--- a/project/templates/stats.html
+++ b/project/templates/stats.html
@@ -69,15 +69,15 @@
                 {% for row in stats: %}
                 <tr>
                     <td class="dataIP ipToLink selectt"><a href="{{url_for('main.ipStats', ipAddr=row['remoteaddr'])}}">{{row['remoteaddr']}}</a></td>
-                    <td class="dataURL selectt">{{row['url']}}</td>
+                    <td class="dataURL dataToLink selectt"><a href="{{url_for('main.urlStats', url=row['url'])}}">{{row['url']}}</a></td>
                     <td class="dataMethod selectt">{{row['requestmethod']}}</td>
-                    <td class="dataQueryString selectt">{{row['querystring']}}</td>
+                    <td class="dataQueryString dataToLink mono smaller selectt"><a href="{{url_for('main.queriesStats', query=row['querystring'])}}">{{row['querystring']}}</a></td>
                     <td class="dataHostname selectt">{{row['hostname']}}</td>
                     <td class="dataTime selectt">{{row['time']}}</td>
-                    <td class="dataPostData selectt">{{row['postjson']}}</td>
-                    <td class="dataUA selectt">{{row['useragent']}}</td>
-                    <td class="dataHeaders httpHeaders selectt hidden">{{row['headers']}}</td>
-                    <td class="dataLinks ipToLink"><a href="https://www.abuseipdb.com/check/{{row['remoteaddr']}}" target="_blank">AbuseIPDB</a> | <a href="https://ipinfo.io/{{row['remoteaddr']}}" target="_blank">IPinfo.io</a></td>
+                    <td class="dataPostData mono smaller selectt">{{row['postjson']}}</td>
+                    <td class="dataUA dataToLink selectt"><a href="{{url_for('main.uaStats', ua=row['useragent'])}}">{{row['useragent']|e}}</a></td>
+                    <td class="dataHeaders smallerer mono selectt hidden">{{row['headers']}}</td>
+                    <td class="dataLinks ipToLink"><a href="https://www.abuseipdb.com/check/{{row['remoteaddr']}}" target="_blank">AbuseIPDB</a> <span class="dim">|</span> <a href="https://ipinfo.io/{{row['remoteaddr']}}" target="_blank">IPinfo.io</a></td>
                 </tr>
                 {% endfor %}
             </table>

--- a/project/templates/stats.html
+++ b/project/templates/stats.html
@@ -19,6 +19,9 @@
             <div id="dataToggles">
                 Toggle data columns:
                 <label>
+                    <input type="checkbox" name="dataCheckbox" value="dataIP" checked>IP
+                </label>
+                <label>
                     <input type="checkbox" name="dataCheckbox" value="dataURL" checked>URL
                 </label>
                 <label>
@@ -51,7 +54,7 @@
             <table>
                 <thead>
                 <tr>
-                    <th>IP</th>
+                    <th class="dataIP selectt">IP</th>
                     <th class="dataURL selectt">URL</th>
                     <th class="dataMethod selectt">Method</th>
                     <th class="dataQueryString selectt">Query String</th>
@@ -65,7 +68,7 @@
                 </thead>
                 {% for row in stats: %}
                 <tr>
-                    <td class="ipToLink"><a href="{{url_for('main.ipStats', ipAddr=row['remoteaddr'])}}">{{row['remoteaddr']}}</a></td>
+                    <td class="dataIP ipToLink selectt"><a href="{{url_for('main.ipStats', ipAddr=row['remoteaddr'])}}">{{row['remoteaddr']}}</a></td>
                     <td class="dataURL selectt">{{row['url']}}</td>
                     <td class="dataMethod selectt">{{row['requestmethod']}}</td>
                     <td class="dataQueryString selectt">{{row['querystring']}}</td>


### PR DESCRIPTION
1. Redact session cookies before logging request, so they aren't exposed.
2. Add view functions for URL, User-Agent, and Query param stats.
3. Use ISO8601 timestamps for compatibility with AbuseIPDB api.
4. Some minor formatting changes for easier reading of stats.