### PR TITLE
Refactor a few rules to use regex

### DIFF
--- a/test/netgear.py
+++ b/test/netgear.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Test detection of Netgear DGN command injection
+
+import requests
+
+url = 'http://localhost:5000/setup.cgi?next_file=netgear.cfg&todo=syscmd&cmd=cat+/www/.htpasswd&curpath=/&currentsetting.htm=1'
+url_short = 'http://localhost:5000/setup.cgi?currentsetting.htm=1'
+
+# Both requests should be reported.
+x = requests.get(url)
+y = requests.get(url_short)
+print(x.status_code)
+print(y.status_code)


### PR DESCRIPTION
1. Refactor a few detection rules to use regex instead of sloppy string searching.
2. Edit some rule descriptions for clarity.
